### PR TITLE
Update to the main.dart

### DIFF
--- a/chapter01/lib/main.dart
+++ b/chapter01/lib/main.dart
@@ -19,7 +19,7 @@ void main() async {
   );
 }
 
-class GoldRush with Loadable, Game {
+class GoldRush with Game { 
 
   static const int squareSpeed = 250; // The speed that our square will animate
   static final squarePaint = BasicPalette.green.paint(); // The color of the square


### PR DESCRIPTION
With the Loadable class added to the GameRush class, you will get this error "Classes can only mix with Classes and Mixins"
I have fixed this error by removing the Loadable class.